### PR TITLE
feat: adds the `remove` command type

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -7,7 +7,7 @@ import PackageManagers from '../../components/PackageManagers.astro'
 ## Features
 
 - Support for various package managers: [npm](https://www.npmjs.com), [yarn](https://yarnpkg.com), [pnpm](https://pnpm.io), [bun](https://bun.sh) & [ni](https://github.com/antfu/ni).
-- Support for various types of command: [`add`](/usage/#add), [`create`](/usage/#create), [`exec`](/usage/#exec), [`run`](/usage/#run) & [`uninstall`](/usage/#uninstall).
+- Support for various types of command: [`add`](/usage/#add), [`create`](/usage/#create), [`exec`](/usage/#exec), [`run`](/usage/#run) & [`remove`](/usage/#remove).
 - Synced tabs between each instance on the same page.
 - Customizable output with [extra arguments](/usage/#extra-arguments), [comments](/usage/#comment) & [prefixes](/usage/#prefix).
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -7,7 +7,7 @@ import PackageManagers from '../../components/PackageManagers.astro'
 ## Features
 
 - Support for various package managers: [npm](https://www.npmjs.com), [yarn](https://yarnpkg.com), [pnpm](https://pnpm.io), [bun](https://bun.sh) & [ni](https://github.com/antfu/ni).
-- Support for various types of command: [`add`](/usage/#add), [`create`](/usage/#create), [`exec`](/usage/#exec) & [`run`](/usage/#run).
+- Support for various types of command: [`add`](/usage/#add), [`create`](/usage/#create), [`exec`](/usage/#exec), [`run`](/usage/#run) & [`uninstall`](/usage/#uninstall).
 - Synced tabs between each instance on the same page.
 - Customizable output with [extra arguments](/usage/#extra-arguments), [comments](/usage/#comment) & [prefixes](/usage/#prefix).
 

--- a/docs/src/content/docs/usage.mdx
+++ b/docs/src/content/docs/usage.mdx
@@ -94,19 +94,19 @@ The code above generates the following commands:
 
 <PackageManagers type="run" args="dev" />
 
-### `uninstall`
+### `remove`
 
-The `pkg` prop is used to specify the name of the package to uninstall.
+The `pkg` prop is used to specify the name of the package to remove.
 
-```mdx title="src/content/docs/example.mdx" 'type="uninstall"'
+```mdx title="src/content/docs/example.mdx" 'type="remove"'
 import { PackageManagers } from 'starlight-package-managers'
 
-<PackageManagers type="uninstall" pkg="@astrojs/starlight" />
+<PackageManagers type="remove" pkg="@astrojs/starlight" />
 ```
 
 The code above generates the following commands:
 
-<PackageManagers type="uninstall" pkg="@astrojs/starlight" />
+<PackageManagers type="remove" pkg="@astrojs/starlight" />
 
 ## Extra arguments
 

--- a/docs/src/content/docs/usage.mdx
+++ b/docs/src/content/docs/usage.mdx
@@ -94,6 +94,20 @@ The code above generates the following commands:
 
 <PackageManagers type="run" args="dev" />
 
+### `uninstall`
+
+The `pkg` prop is used to specify the name of the package to uninstall.
+
+```mdx title="src/content/docs/example.mdx" 'type="uninstall"'
+import { PackageManagers } from 'starlight-package-managers'
+
+<PackageManagers type="uninstall" pkg="@astrojs/starlight" />
+```
+
+The code above generates the following commands:
+
+<PackageManagers type="uninstall" pkg="@astrojs/starlight" />
+
 ## Extra arguments
 
 You can provide extra arguments to any command using the `args` prop.

--- a/packages/starlight-package-managers/pkg.ts
+++ b/packages/starlight-package-managers/pkg.ts
@@ -9,7 +9,7 @@ const commands: Commands = {
     devOption: '-D',
     exec: 'npx',
     run: 'npm run',
-    remove: 'npm remove',
+    remove: 'npm uninstall',
   },
   yarn: {
     add: 'yarn add',

--- a/packages/starlight-package-managers/pkg.ts
+++ b/packages/starlight-package-managers/pkg.ts
@@ -9,7 +9,7 @@ const commands: Commands = {
     devOption: '-D',
     exec: 'npx',
     run: 'npm run',
-    uninstall: 'npm uninstall',
+    remove: 'npm remove',
   },
   yarn: {
     add: 'yarn add',
@@ -17,7 +17,7 @@ const commands: Commands = {
     devOption: '-D',
     exec: 'yarn',
     run: 'yarn run',
-    uninstall: 'yarn remove',
+    remove: 'yarn remove',
   },
   pnpm: {
     add: 'pnpm add',
@@ -25,21 +25,21 @@ const commands: Commands = {
     devOption: '-D',
     exec: 'pnpm',
     run: 'pnpm run',
-    uninstall: 'pnpm remove',
+    remove: 'pnpm remove',
   },
   bun: {
     add: 'bun add',
     devOption: '-d',
     exec: 'bunx',
     run: 'bun run',
-    uninstall: 'bun remove',
+    remove: 'bun remove',
   },
   ni: {
     add: 'ni',
     devOption: '-D',
     exec: 'nlx',
     run: 'nr',
-    uninstall: 'nun',
+    remove: 'nun',
   },
 }
 
@@ -98,7 +98,7 @@ export function getCommand(
   return command
 }
 
-export type CommandType = 'add' | 'create' | 'exec' | 'run' | 'uninstall'
+export type CommandType = 'add' | 'create' | 'exec' | 'run' | 'remove'
 
 export interface CommandOptions {
   args?: string

--- a/packages/starlight-package-managers/pkg.ts
+++ b/packages/starlight-package-managers/pkg.ts
@@ -9,6 +9,7 @@ const commands: Commands = {
     devOption: '-D',
     exec: 'npx',
     run: 'npm run',
+    uninstall: 'npm uninstall',
   },
   yarn: {
     add: 'yarn add',
@@ -16,6 +17,7 @@ const commands: Commands = {
     devOption: '-D',
     exec: 'yarn',
     run: 'yarn run',
+    uninstall: 'yarn remove',
   },
   pnpm: {
     add: 'pnpm add',
@@ -23,18 +25,21 @@ const commands: Commands = {
     devOption: '-D',
     exec: 'pnpm',
     run: 'pnpm run',
+    uninstall: 'pnpm remove',
   },
   bun: {
     add: 'bun add',
     devOption: '-d',
     exec: 'bunx',
     run: 'bun run',
+    uninstall: 'bun remove',
   },
   ni: {
     add: 'ni',
     devOption: '-D',
     exec: 'nlx',
     run: 'nr',
+    uninstall: 'nun',
   },
 }
 
@@ -93,7 +98,7 @@ export function getCommand(
   return command
 }
 
-export type CommandType = 'add' | 'create' | 'exec' | 'run'
+export type CommandType = 'add' | 'create' | 'exec' | 'run' | 'uninstall'
 
 export interface CommandOptions {
   args?: string

--- a/packages/starlight-package-managers/tests/unit/commands.test.ts
+++ b/packages/starlight-package-managers/tests/unit/commands.test.ts
@@ -83,7 +83,7 @@ pnpm create astro`,
 
   test("should generate the 'remove' command", () => {
     expect(getCommands('remove', 'astro', {})).toEqual([
-      'npm remove astro',
+      'npm uninstall astro',
       'yarn remove astro',
       'pnpm remove astro',
       'bun remove astro',

--- a/packages/starlight-package-managers/tests/unit/commands.test.ts
+++ b/packages/starlight-package-managers/tests/unit/commands.test.ts
@@ -81,9 +81,9 @@ pnpm create astro`,
     ])
   })
 
-  test("should generate the 'uninstall' command", () => {
-    expect(getCommands('uninstall', 'astro', {})).toEqual([
-      'npm uninstall astro',
+  test("should generate the 'remove' command", () => {
+    expect(getCommands('remove', 'astro', {})).toEqual([
+      'npm remove astro',
       'yarn remove astro',
       'pnpm remove astro',
       'bun remove astro',

--- a/packages/starlight-package-managers/tests/unit/commands.test.ts
+++ b/packages/starlight-package-managers/tests/unit/commands.test.ts
@@ -80,6 +80,16 @@ yarn create astro`,
 pnpm create astro`,
     ])
   })
+
+  test("should generate the 'uninstall' command", () => {
+    expect(getCommands('uninstall', 'astro', {})).toEqual([
+      'npm uninstall astro',
+      'yarn remove astro',
+      'pnpm remove astro',
+      'bun remove astro',
+      'nun astro',
+    ])
+  })
 })
 
 describe('exec', () => {


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
Please provide as much details as possible, including screenshots or sample code if necessary.
-->

**Describe the pull request**

Add a remove command.

**Why**

Can be useful for giving instructions for migrating from one package to another.

**How**

Following these docs:

- npm: https://docs.npmjs.com/uninstalling-packages-and-dependencies#example
- Yarn: https://yarnpkg.com/cli/remove
- pnpm: https://pnpm.io/cli/remove
- bun: https://bun.sh/docs/cli/remove
- ni: https://github.com/antfu-collective/ni

**Screenshots**

<img width="755" alt="Screenshot 2024-05-22 at 21 36 07" src="https://github.com/HiDeoo/starlight-package-managers/assets/15347255/996fb84d-546b-42ed-a911-421bb4529e6e">

<img width="748" alt="Screenshot 2024-05-22 at 21 36 10" src="https://github.com/HiDeoo/starlight-package-managers/assets/15347255/48268e3f-86ef-4dce-859e-ed01eaf9f1bf">


<!-- Feel free to add additional comments. -->

**Note**

~~Some commands call this `uninstall`, others call it `remove`. I went with `uninstall` since that's what npm calls it. Another option could be to also include a `remove` command and have it return the same results.~~ Changed to `remove`