### PR TITLE
feat: adds the `dlx` command type

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -7,7 +7,7 @@ import PackageManagers from '../../components/PackageManagers.astro'
 ## Features
 
 - Support for various package managers: [npm](https://www.npmjs.com), [yarn](https://yarnpkg.com), [pnpm](https://pnpm.io), [bun](https://bun.sh) & [ni](https://github.com/antfu/ni).
-- Support for various types of command: [`add`](/usage/#add), [`create`](/usage/#create), [`exec`](/usage/#exec), [`run`](/usage/#run) & [`remove`](/usage/#remove).
+- Support for various types of command: [`add`](/usage/#add), [`create`](/usage/#create), [`dlx`](/usage/#dlx), [`exec`](/usage/#exec), [`run`](/usage/#run) & [`remove`](/usage/#remove).
 - Synced tabs between each instance on the same page.
 - Customizable output with [extra arguments](/usage/#extra-arguments), [comments](/usage/#comment) & [prefixes](/usage/#prefix).
 

--- a/docs/src/content/docs/usage.mdx
+++ b/docs/src/content/docs/usage.mdx
@@ -66,6 +66,18 @@ The code above generates the following commands:
 
 <PackageManagers type="create" pkg="astro@latest" />
 
+### `dlx`
+
+To fetch and execute a package binary, without installing it as a dependency, you can use the `dlx` type and specify extra arguments using the `args` prop.
+
+```mdx title="src/content/docs/example.mdx" 'type="dlx"'
+<PackageManagers type="dlx" pkg="serve" args="public" />
+```
+
+The code above generates the following commands:
+
+<PackageManagers type="dlx" pkg="serve" args="public" />
+
 ### `exec`
 
 To execute a package binary, you can use the `exec` type and specify extra arguments using the `args` prop.

--- a/packages/starlight-package-managers/README.md
+++ b/packages/starlight-package-managers/README.md
@@ -61,7 +61,7 @@ By this one:
 ## Features
 
 - Support for various package managers: [npm](https://www.npmjs.com), [yarn](https://yarnpkg.com), [pnpm](https://pnpm.io), [bun](https://bun.sh) & [ni](https://github.com/antfu/ni).
-- Support for various types of command: [`add`](https://starlight-package-managers.vercel.app/usage/#add), [`create`](https://starlight-package-managers.vercel.app/usage/#create), [`exec`](https://starlight-package-managers.vercel.app/usage/#exec), [`run`](https://starlight-package-managers.vercel.app/usage/#run) & [`remove`](https://starlight-package-managers.vercel.app/usage/#remove).
+- Support for various types of command: [`add`](https://starlight-package-managers.vercel.app/usage/#add), [`create`](https://starlight-package-managers.vercel.app/usage/#create), [`dlx`](https://starlight-package-managers.vercel.app/usage/#dlx), [`exec`](https://starlight-package-managers.vercel.app/usage/#exec), [`run`](https://starlight-package-managers.vercel.app/usage/#run) & [`remove`](https://starlight-package-managers.vercel.app/usage/#remove).
 - Synced tabs between each instance on the same page.
 - Customizable output with [extra arguments](https://starlight-package-managers.vercel.app/usage/#extra-arguments), [comments](https://starlight-package-managers.vercel.app/usage/#comment) & [prefixes](https://starlight-package-managers.vercel.app/usage/#prefix).
 

--- a/packages/starlight-package-managers/pkg.ts
+++ b/packages/starlight-package-managers/pkg.ts
@@ -7,6 +7,7 @@ const commands: Commands = {
     add: 'npm i',
     create: 'npm create',
     devOption: '-D',
+    dlx: 'npx',
     exec: 'npx',
     run: 'npm run',
     remove: 'npm uninstall',
@@ -15,6 +16,7 @@ const commands: Commands = {
     add: 'yarn add',
     create: 'yarn create',
     devOption: '-D',
+    dlx: 'yarn dlx',
     exec: 'yarn',
     run: 'yarn run',
     remove: 'yarn remove',
@@ -23,6 +25,7 @@ const commands: Commands = {
     add: 'pnpm add',
     create: 'pnpm create',
     devOption: '-D',
+    dlx: 'pnpm dlx',
     exec: 'pnpm',
     run: 'pnpm run',
     remove: 'pnpm remove',
@@ -30,6 +33,7 @@ const commands: Commands = {
   bun: {
     add: 'bun add',
     devOption: '-d',
+    dlx: 'bunx',
     exec: 'bunx',
     run: 'bun run',
     remove: 'bun remove',
@@ -37,6 +41,7 @@ const commands: Commands = {
   ni: {
     add: 'ni',
     devOption: '-D',
+    dlx: 'nlx',
     exec: 'nlx',
     run: 'nr',
     remove: 'nun',
@@ -88,7 +93,7 @@ export function getCommand(
   }
 
   if (options.args && options.args.length > 0) {
-    if (pkgManager === 'npm' && type !== 'exec' && type !== 'run') {
+    if (pkgManager === 'npm' && type !== 'dlx' && type !== 'exec' && type !== 'run') {
       command += ' --'
     }
 
@@ -98,7 +103,7 @@ export function getCommand(
   return command
 }
 
-export type CommandType = 'add' | 'create' | 'exec' | 'run' | 'remove'
+export type CommandType = 'add' | 'create' | 'dlx' | 'exec' | 'run' | 'remove'
 
 export interface CommandOptions {
   args?: string

--- a/packages/starlight-package-managers/tests/unit/commands.test.ts
+++ b/packages/starlight-package-managers/tests/unit/commands.test.ts
@@ -92,6 +92,18 @@ pnpm create astro`,
   })
 })
 
+describe('dlx', () => {
+  test("should generate the 'dlx' command", () => {
+    expect(getCommands('dlx', 'serve', { args: 'public' })).toEqual([
+      'npx serve public',
+      'yarn dlx serve public',
+      'pnpm dlx serve public',
+      'bunx serve public',
+      'nlx serve public',
+    ])
+  })
+})
+
 describe('exec', () => {
   test("should generate the 'exec' command", () => {
     expect(getCommands('exec', 'astro', { args: 'add solid' })).toEqual([


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
Please provide as much details as possible, including screenshots or sample code if necessary.
-->

**Describe the pull request**

From the discussion in #11, this adds support for the `dlx` command.

**Why**

See #11

**How**

By mirroring the implementation of the `exec` command.

**Screenshots**

N/A

<!-- Feel free to add additional comments. -->

---

Note: for pnpm, whilst there is an alias — `pnpx` — I've chosen to use `pnpm dlx`, as the alias was only introduced in pnpm v9 (Apr 2024).
