### PR TITLE
Use alphabetical order for default package managers

### DIFF
--- a/.changeset/mighty-books-occur.md
+++ b/.changeset/mighty-books-occur.md
@@ -1,0 +1,7 @@
+---
+'starlight-package-managers': minor
+---
+
+Changes the default order of default package managers to be alphabetical (`npm`, `pnpm`, and `yarn` instead of `npm`, `yarn`, and `pnpm`).
+
+If you want to preserve the previous behaviour, you can check the [“Global Customization” guide](http://localhost:4321/guides/package-managers#global-customization) and manually specify the package managers order you want.

--- a/packages/starlight-package-managers/pkg.ts
+++ b/packages/starlight-package-managers/pkg.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const pkgManagers = ['npm', 'yarn', 'pnpm', 'bun', 'ni'] as const
 
-const defaultPkgManagers: PackageManager[] = ['npm', 'yarn', 'pnpm']
+const defaultPkgManagers: PackageManager[] = ['npm', 'pnpm', 'yarn']
 
 const commands: Commands = {
   npm: {

--- a/packages/starlight-package-managers/tests/unit/commands.test.ts
+++ b/packages/starlight-package-managers/tests/unit/commands.test.ts
@@ -159,7 +159,7 @@ describe('package managers', () => {
       getSupportedPkgManagers('add', undefined).map((pkgManager) => {
         return getCommand(pkgManager, 'add', 'astro', {})
       }),
-    ).toEqual(['npm i astro', 'yarn add astro', 'pnpm add astro'])
+    ).toEqual(['npm i astro', 'pnpm add astro', 'yarn add astro'])
   })
 
   test('should support overriding the package managers', () => {


### PR DESCRIPTION
Close #23 