### PR TITLE
fix: #29 remove versions from yarn create commands

### DIFF
--- a/.changeset/silent-rings-guess.md
+++ b/.changeset/silent-rings-guess.md
@@ -1,0 +1,5 @@
+---
+'starlight-package-managers': patch
+---
+
+Strips version from package names for the [`create`](https://starlight-package-managers.vercel.app/usage/#create) command type for the `yarn` package manager which [does not support](https://github.com/yarnpkg/yarn/issues/6587) versioned package names for this command type.

--- a/packages/starlight-package-managers/pkg.ts
+++ b/packages/starlight-package-managers/pkg.ts
@@ -90,7 +90,10 @@ export function getCommand(
   }
 
   if (pkg) {
-    // Strip @version from package name for yarn create commands
+    /**
+     * Strip `@version` from package name for yarn create commands.
+     * @see https://github.com/yarnpkg/yarn/issues/6587
+     */
     const processedPkg = type === 'create' && pkgManager === 'yarn' ? pkg.replace(/@[^\s]+/, '') : pkg
     command += ` ${processedPkg}`
   }

--- a/packages/starlight-package-managers/pkg.ts
+++ b/packages/starlight-package-managers/pkg.ts
@@ -90,7 +90,9 @@ export function getCommand(
   }
 
   if (pkg) {
-    command += ` ${pkg}`
+    // Strip @version from package name for yarn create commands
+    const processedPkg = type === 'create' && pkgManager === 'yarn' ? pkg.replace(/@[^\s]+/, '') : pkg
+    command += ` ${processedPkg}`
   }
 
   if (options.args && options.args.length > 0) {

--- a/packages/starlight-package-managers/tests/unit/commands.test.ts
+++ b/packages/starlight-package-managers/tests/unit/commands.test.ts
@@ -44,10 +44,20 @@ describe('add', () => {
 
 describe('create', () => {
   test("should generate the 'create' command for supported package managers", () => {
+    expect(getCommands('create', 'astro', {})).toEqual(['npm create astro', 'yarn create astro', 'pnpm create astro'])
+  })
+
+  test("should strip versions for the  'create' command with yarn", () => {
     expect(getCommands('create', 'astro@latest', {})).toEqual([
       'npm create astro@latest',
       'yarn create astro',
       'pnpm create astro@latest',
+    ])
+
+    expect(getCommands('create', 'astro@5.1.2', {})).toEqual([
+      'npm create astro@5.1.2',
+      'yarn create astro',
+      'pnpm create astro@5.1.2',
     ])
   })
 

--- a/packages/starlight-package-managers/tests/unit/commands.test.ts
+++ b/packages/starlight-package-managers/tests/unit/commands.test.ts
@@ -46,7 +46,7 @@ describe('create', () => {
   test("should generate the 'create' command for supported package managers", () => {
     expect(getCommands('create', 'astro@latest', {})).toEqual([
       'npm create astro@latest',
-      'yarn create astro@latest',
+      'yarn create astro',
       'pnpm create astro@latest',
     ])
   })


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
Please provide as much details as possible, including screenshots or sample code if necessary.
-->

**Describe the pull request**

Fixes https://github.com/HiDeoo/starlight-package-managers/issues/29

**Why**

Yarn create commands with a version are invalid

**How**

Strip the version from the `pkg` in `getCommand`

**Screenshots**

If applicable, add screenshots to help explain what is being modified.

<!-- Feel free to add additional comments. -->
