### PR TITLE
Feature: Add install command

### DIFF
--- a/.changeset/heavy-fans-jump.md
+++ b/.changeset/heavy-fans-jump.md
@@ -2,4 +2,4 @@
 'starlight-package-managers': minor
 ---
 
-Added support for the `install` command, for installing all dependencies specified in the package.json file.
+Adds the `install` command type to install all dependencies for a project.

--- a/.changeset/heavy-fans-jump.md
+++ b/.changeset/heavy-fans-jump.md
@@ -1,0 +1,5 @@
+---
+'starlight-package-managers': minor
+---
+
+Added support for the `install` command, for installing all dependencies specified in the package.json file.

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -7,7 +7,7 @@ import PackageManagers from '../../components/PackageManagers.astro'
 ## Features
 
 - Support for various package managers: [npm](https://www.npmjs.com), [yarn](https://yarnpkg.com), [pnpm](https://pnpm.io), [bun](https://bun.sh) & [ni](https://github.com/antfu/ni).
-- Support for various types of command: [`add`](/usage/#add), [`create`](/usage/#create), [`dlx`](/usage/#dlx), [`exec`](/usage/#exec), [`run`](/usage/#run) & [`remove`](/usage/#remove).
+- Support for various types of command: [`add`](/usage/#add), [`create`](/usage/#create), [`dlx`](/usage/#dlx), [`exec`](/usage/#exec), [`install`](/usage/#install), [`remove`](/usage/#remove) & [`run`](/usage/#run).
 - Synced tabs between each instance on the same page.
 - Customizable output with [extra arguments](/usage/#extra-arguments), [comments](/usage/#comment) & [prefixes](/usage/#prefix).
 

--- a/docs/src/content/docs/usage.mdx
+++ b/docs/src/content/docs/usage.mdx
@@ -96,7 +96,7 @@ The code above generates the following commands:
 
 To install all dependencies, you can use the `install` type, with no other props specified.
 
-```mdx title="src/content/docs/example.mdx" 'type="exec"' 'args="add solid"'
+```mdx title="src/content/docs/example.mdx" 'type="install"'
 import { PackageManagers } from 'starlight-package-managers'
 
 <PackageManagers type="install" />

--- a/docs/src/content/docs/usage.mdx
+++ b/docs/src/content/docs/usage.mdx
@@ -106,20 +106,6 @@ The code above generates the following commands:
 
 <PackageManagers type="install" />
 
-### `run`
-
-To run a script defined in the package's manifest file, you can use the `run` type and specify the name of the name of the script using the `args` prop.
-
-```mdx title="src/content/docs/example.mdx" 'type="run"' 'args="dev"'
-import { PackageManagers } from 'starlight-package-managers'
-
-<PackageManagers type="run" args="dev" />
-```
-
-The code above generates the following commands:
-
-<PackageManagers type="run" args="dev" />
-
 ### `remove`
 
 The `pkg` prop is used to specify the name of the package to remove.
@@ -133,6 +119,20 @@ import { PackageManagers } from 'starlight-package-managers'
 The code above generates the following commands:
 
 <PackageManagers type="remove" pkg="@astrojs/starlight" />
+
+### `run`
+
+To run a script defined in the package's manifest file, you can use the `run` type and specify the name of the name of the script using the `args` prop.
+
+```mdx title="src/content/docs/example.mdx" 'type="run"' 'args="dev"'
+import { PackageManagers } from 'starlight-package-managers'
+
+<PackageManagers type="run" args="dev" />
+```
+
+The code above generates the following commands:
+
+<PackageManagers type="run" args="dev" />
 
 ## Extra arguments
 

--- a/docs/src/content/docs/usage.mdx
+++ b/docs/src/content/docs/usage.mdx
@@ -92,6 +92,20 @@ The code above generates the following commands:
 
 <PackageManagers type="exec" pkg="astro" args="add solid" />
 
+### `install`
+
+To install all dependencies, you can use the `install` type, with no other props specified.
+
+```mdx title="src/content/docs/example.mdx" 'type="exec"' 'args="add solid"'
+import { PackageManagers } from 'starlight-package-managers'
+
+<PackageManagers type="install" />
+```
+
+The code above generates the following commands:
+
+<PackageManagers type="install" />
+
 ### `run`
 
 To run a script defined in the package's manifest file, you can use the `run` type and specify the name of the name of the script using the `args` prop.

--- a/packages/starlight-package-managers/README.md
+++ b/packages/starlight-package-managers/README.md
@@ -61,7 +61,7 @@ By this one:
 ## Features
 
 - Support for various package managers: [npm](https://www.npmjs.com), [yarn](https://yarnpkg.com), [pnpm](https://pnpm.io), [bun](https://bun.sh) & [ni](https://github.com/antfu/ni).
-- Support for various types of command: [`add`](https://starlight-package-managers.vercel.app/usage/#add), [`create`](https://starlight-package-managers.vercel.app/usage/#create), [`dlx`](https://starlight-package-managers.vercel.app/usage/#dlx), [`exec`](https://starlight-package-managers.vercel.app/usage/#exec), [`install`](https://starlight-package-managers.vercel.app/usage/#install), [`run`](https://starlight-package-managers.vercel.app/usage/#run) & [`remove`](https://starlight-package-managers.vercel.app/usage/#remove).
+- Support for various types of command: [`add`](https://starlight-package-managers.vercel.app/usage/#add), [`create`](https://starlight-package-managers.vercel.app/usage/#create), [`dlx`](https://starlight-package-managers.vercel.app/usage/#dlx), [`exec`](https://starlight-package-managers.vercel.app/usage/#exec), [`install`](https://starlight-package-managers.vercel.app/usage/#install), [`remove`](https://starlight-package-managers.vercel.app/usage/#remove) & [`run`](https://starlight-package-managers.vercel.app/usage/#run).
 - Synced tabs between each instance on the same page.
 - Customizable output with [extra arguments](https://starlight-package-managers.vercel.app/usage/#extra-arguments), [comments](https://starlight-package-managers.vercel.app/usage/#comment) & [prefixes](https://starlight-package-managers.vercel.app/usage/#prefix).
 

--- a/packages/starlight-package-managers/README.md
+++ b/packages/starlight-package-managers/README.md
@@ -61,7 +61,7 @@ By this one:
 ## Features
 
 - Support for various package managers: [npm](https://www.npmjs.com), [yarn](https://yarnpkg.com), [pnpm](https://pnpm.io), [bun](https://bun.sh) & [ni](https://github.com/antfu/ni).
-- Support for various types of command: [`add`](https://starlight-package-managers.vercel.app/usage/#add), [`create`](https://starlight-package-managers.vercel.app/usage/#create), [`dlx`](https://starlight-package-managers.vercel.app/usage/#dlx), [`exec`](https://starlight-package-managers.vercel.app/usage/#exec), [`run`](https://starlight-package-managers.vercel.app/usage/#run) & [`remove`](https://starlight-package-managers.vercel.app/usage/#remove).
+- Support for various types of command: [`add`](https://starlight-package-managers.vercel.app/usage/#add), [`create`](https://starlight-package-managers.vercel.app/usage/#create), [`dlx`](https://starlight-package-managers.vercel.app/usage/#dlx), [`exec`](https://starlight-package-managers.vercel.app/usage/#exec), [`install`](https://starlight-package-managers.vercel.app/usage/#install), [`run`](https://starlight-package-managers.vercel.app/usage/#run) & [`remove`](https://starlight-package-managers.vercel.app/usage/#remove).
 - Synced tabs between each instance on the same page.
 - Customizable output with [extra arguments](https://starlight-package-managers.vercel.app/usage/#extra-arguments), [comments](https://starlight-package-managers.vercel.app/usage/#comment) & [prefixes](https://starlight-package-managers.vercel.app/usage/#prefix).
 

--- a/packages/starlight-package-managers/pkg.ts
+++ b/packages/starlight-package-managers/pkg.ts
@@ -114,7 +114,7 @@ export function getCommand(
   return command
 }
 
-export type CommandType = 'add' | 'create' | 'dlx' | 'exec' | 'install' | 'run' | 'remove'
+export type CommandType = 'add' | 'create' | 'dlx' | 'exec' | 'install' | 'remove' | 'run'
 
 export interface CommandOptions {
   args?: string

--- a/packages/starlight-package-managers/pkg.ts
+++ b/packages/starlight-package-managers/pkg.ts
@@ -10,6 +10,7 @@ const commands: Commands = {
     devOption: '-D',
     dlx: 'npx',
     exec: 'npx',
+    install: 'npm install',
     run: 'npm run',
     remove: 'npm uninstall',
   },
@@ -19,6 +20,7 @@ const commands: Commands = {
     devOption: '-D',
     dlx: 'yarn dlx',
     exec: 'yarn',
+    install: 'yarn install',
     run: 'yarn run',
     remove: 'yarn remove',
   },
@@ -28,6 +30,7 @@ const commands: Commands = {
     devOption: '-D',
     dlx: 'pnpx',
     exec: 'pnpm',
+    install: 'pnpm install',
     run: 'pnpm run',
     remove: 'pnpm remove',
   },
@@ -36,6 +39,7 @@ const commands: Commands = {
     devOption: '-d',
     dlx: 'bunx',
     exec: 'bunx',
+    install: 'bun install',
     run: 'bun run',
     remove: 'bun remove',
   },
@@ -44,6 +48,7 @@ const commands: Commands = {
     devOption: '-D',
     dlx: 'nlx',
     exec: 'nlx',
+    install: 'ni',
     run: 'nr',
     remove: 'nun',
   },
@@ -109,7 +114,7 @@ export function getCommand(
   return command
 }
 
-export type CommandType = 'add' | 'create' | 'dlx' | 'exec' | 'run' | 'remove'
+export type CommandType = 'add' | 'create' | 'dlx' | 'exec' | 'install' | 'run' | 'remove'
 
 export interface CommandOptions {
   args?: string

--- a/packages/starlight-package-managers/tests/unit/commands.test.ts
+++ b/packages/starlight-package-managers/tests/unit/commands.test.ts
@@ -126,6 +126,42 @@ describe('exec', () => {
   })
 })
 
+describe('install', () => {
+  test("should generate the 'install' command", () => {
+    expect(getCommands('install', '', {})).toEqual(['npm install', 'yarn install', 'pnpm install', 'bun install', 'ni'])
+  })
+
+  test("should generate the 'install' command with a comment", () => {
+    expect(getCommands('install', '', { comment: 'install dependencies' })).toEqual([
+      `# install dependencies
+npm install`,
+      `# install dependencies
+yarn install`,
+      `# install dependencies
+pnpm install`,
+      `# install dependencies
+bun install`,
+      `# install dependencies
+ni`,
+    ])
+  })
+
+  test("should generate the 'install' command with a comment including the package manager", () => {
+    expect(getCommands('install', '', { comment: 'install dependencies with {PKG} and {PKG}' })).toEqual([
+      `# install dependencies with npm and npm
+npm install`,
+      `# install dependencies with yarn and yarn
+yarn install`,
+      `# install dependencies with pnpm and pnpm
+pnpm install`,
+      `# install dependencies with bun and bun
+bun install`,
+      `# install dependencies with ni and ni
+ni`,
+    ])
+  })
+})
+
 describe('run', () => {
   test("should generate the 'run' command", () => {
     expect(getCommands('run', '', { args: 'dev' })).toEqual([


### PR DESCRIPTION
## Motivation

The `add` command on pnpm (`pnpm add`), when supplied on its own, does not act like in other package managers do.
* For the other package managers, it acts as an alias to a package-less `install` command (i.e. installs all dependencies as defined in package.lock.json).
* In pnpm, it causes a command syntax error.

This PR solves this issue by adding the `install` command, which has consistent behavior between package managers. It also allows for a more semantically accurate markdown syntax.

## Usage

```mdx
<PackageManagers type="install" />
```

Resulting commands:
```bash
npm install
yarn install
pnpm install
bun install
ni
```