### PR TITLE
fix: convert shorthand attribute syntax for Vite 8 compatibility

### DIFF
--- a/packages/starlight-package-managers/PackageManagers.astro
+++ b/packages/starlight-package-managers/PackageManagers.astro
@@ -40,12 +40,12 @@ function getTabItemProps(pkgManager: PackageManager) {
 
 {
   singlePkgManager ? (
-    <Code code={getCommand(singlePkgManager, type, pkg, options)} lang="sh" {title} frame={ecFrame} />
+    <Code code={getCommand(singlePkgManager, type, pkg, options)} lang="sh" title={title} frame={ecFrame} />
   ) : (
     <Tabs syncKey="starlight-package-managers-pkg">
       {getSupportedPkgManagers(type, pkgManagers).map((pkgManager) => (
         <TabItem {...getTabItemProps(pkgManager)}>
-          <Code code={getCommand(pkgManager, type, pkg, options)} lang="sh" {title} frame={ecFrame} />
+          <Code code={getCommand(pkgManager, type, pkg, options)} lang="sh" title={title} frame={ecFrame} />
         </TabItem>
       ))}
     </Tabs>


### PR DESCRIPTION
## Summary
Converts shorthand JSX attribute syntax `{title}` to explicit `title={title}` to fix Oxc transformer error in Vite 8.

## Problem
When using this package with Astro 6 / Vite 8, the Oxc transformer fails with:
```
Unknown file extension ".astro" for PackageManagers.astro
Failed to parse source for import analysis because the content contains invalid JS syntax
```

## Solution
Change shorthand attribute syntax to explicit form which is properly handled by Vite 8's Oxc transformer.

## Testing
Tested locally with Astro 6 project.

Fixes compatibility with Astro 6 / Vite 8.